### PR TITLE
Personal Page is now updated with the most recent user model

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,8 @@ As for the front-end, our script will bundle all of our JS, CSS and HTML and han
 1) Bundling combines (or bundles) multiple files into a single file (i.e CSS bundles, JS bundles, etc). Fewer files means fewer HTTP requests to retrieve them, which means better page load performance.
 
 2) Minification removes white space and comments and shortens variables names. Saves space.
+
+## How do our reducers work?
+Every time a user makes a request (i.e route in either React or Express, or just about any API call such as action creators), Passport knows to deserialize the user's ID (remember, the ID is in the cookie in the browser) into a User model (We call our GetUserByID endpoint). Then, we call done(...) so that Passport knows to have the most updated User model under the req.user in our Express routes.
+
+Note that redux will always pre-load its data before calling componentDidMount, which is called after the first render.

--- a/client/src/components/Dashboard/Dashboard.js
+++ b/client/src/components/Dashboard/Dashboard.js
@@ -2,11 +2,15 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import completeWorkflowToast from '../../utils/Toasts/default';
+import * as actions from '../../actions/index';
+import { connect } from 'react-redux';
 
 class Dashboard extends Component {
 
     componentDidMount() {
         this.props.showHeader();
+        // Update the user model so that components like the Profile can pre-load the up-to-date model
+        this.props.fetchUser();
         
         var { location } = this.props;
         // Toast if the user just finished the workflow
@@ -25,4 +29,4 @@ class Dashboard extends Component {
     }
 }
 
-export default withRouter(Dashboard);
+export default connect(null, actions)(withRouter(Dashboard));


### PR DESCRIPTION
Please see #37 for reference.

The fix is to get the most recent user in the Dashboard, so when the user comes back, the pre-loaded data will be already updated.