### PR TITLE
Got rid of "unique key" warning in console

### DIFF
--- a/client/src/components/Personal/Personal.js
+++ b/client/src/components/Personal/Personal.js
@@ -72,7 +72,7 @@ class Personal extends Component {
             }
             else if (type === "radio") {
                 // For Fields with type "radio", we must wrap it around a label element for it to work
-                return <label><Field key={key} type={type} label={label} name={name} component={RenderField} value={value} /></label>
+                return <label key={key}><Field type={type} label={label} name={name} component={RenderField} value={value} /></label>
             }
         });
     }

--- a/client/src/components/setup/FormSecondPage/FormSecondPage.js
+++ b/client/src/components/setup/FormSecondPage/FormSecondPage.js
@@ -13,7 +13,7 @@ class FormSecondPage extends Component {
             }
             else if (type === "radio") {
                 // For Fields with type "radio", we must wrap it around a label element for it to work
-                return <label><Field key={key} type={type} label={label} name={name} component={RenderField} value={value} /></label>
+                return <label key={key}><Field type={type} label={label} name={name} component={RenderField} value={value} /></label>
             }
         });
     }


### PR DESCRIPTION
Previously we saw an ugly warning in the console telling us we need unique keys in our list. Turns out, we had to put the key on the outermost object (obivously), which is the Label, not the Field.