### PR TITLE
Refactored CSS

### DIFF
--- a/client/src/components/Error/Error.css
+++ b/client/src/components/Error/Error.css
@@ -1,7 +1,7 @@
 /* The idea here is: push the container to the exact middle of the 
 browser window with left: 50%;, then pull it back to the left edge 
 with negative -50vw margin. */
-.error-background {
+:local(.error_background) {
     height: 100vh;
     width: 100vw;
     position: relative;

--- a/client/src/components/Error/Error.js
+++ b/client/src/components/Error/Error.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import errorToast from '../../utils/Toasts/default';
-import './Error.css';
+import s from './Error.css';
 
 class Error extends Component {
     componentDidMount() {
@@ -17,7 +17,7 @@ class Error extends Component {
     
     render() {
         return (
-            <div className="error-background">
+            <div className={s.error_background}>
                 {errorToast}
             </div>
         );

--- a/client/src/components/Header/Header.css
+++ b/client/src/components/Header/Header.css
@@ -6,7 +6,7 @@ nav {
 }
 
     /* The icon of our app */
-    nav a .library-music {
+    nav a :local(.library_music) {
         line-height: 45px;
         height: 45px;
         color: orange;

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import './Header.css';
+import s from './Header.css';
 
 class Header extends Component {
     renderContent() {
@@ -37,7 +37,7 @@ class Header extends Component {
                     <Link 
                         to={user ? '/dashboard' : '/'}
                         className="left">
-                        <i className="material-icons library-music">library_music</i>
+                        <i className={s.library_music + " material-icons"}>library_music</i>
                     </Link>
                     <ul className="right">
                         {this.renderContent()}

--- a/client/src/components/Personal/Personal.css
+++ b/client/src/components/Personal/Personal.css
@@ -1,0 +1,9 @@
+:local(.form) {
+    max-width: 800px;
+    margin: 0 auto;
+    background-color: white;
+    padding: 50px 35px;
+    box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(0,0,0,0.12);
+    border-radius: 50px;
+    margin-top: 30px;
+}

--- a/client/src/components/Personal/Personal.js
+++ b/client/src/components/Personal/Personal.js
@@ -10,6 +10,7 @@ import { withRouter } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import updateProfileToast from '../../utils/Toasts/default';
+import s from './Personal.css';
 
 class Personal extends Component {
     constructor(props) {
@@ -79,7 +80,7 @@ class Personal extends Component {
 
     render() {
         return (
-            <div className="container">
+            <div className={s.form}>
                 <form onSubmit={this.submitForm.bind(this)}>
                     {this.renderFields()}
                     <Link to={'/dashboard'} className="teal btn-flat left white-text">

--- a/client/src/components/setup/Workflow/Workflow.css
+++ b/client/src/components/setup/Workflow/Workflow.css
@@ -1,5 +1,5 @@
 /* This is a container for our form */
-.form {
+:local(.form) {
     max-width: 800px;
     min-height: 400px;
     margin: 0 auto;
@@ -9,13 +9,13 @@
     border-radius: 50px;
 }
 
-.library-music {
+:local(.library_music) {
     font-size: 70px;
     color: orange;
 }
 
 /* This is the left side of the workflow, where we show the logo and some explainer text */
-.logo-box {
+:local(.logo_box) {
     min-width: 70px; /* This is so when the screen resizes to a smaller one, our redux forms won't overlap */
     line-height: 1.5;
 }

--- a/client/src/components/setup/Workflow/Workflow.js
+++ b/client/src/components/setup/Workflow/Workflow.js
@@ -3,7 +3,7 @@ import FormFirstPage from '../FormFirstPage/FormFirstPage';
 import FormSecondPage from '../FormSecondPage/FormSecondPage';
 import FormThirdPage from '../FormThirdPage';
 import TopBar from '../TopBar/TopBar';
-import './Workflow.css';
+import s from './Workflow.css';
 
 class Workflow extends Component {
     constructor(props) {
@@ -35,9 +35,9 @@ class Workflow extends Component {
             <div>
                 {/* Show the top part of the workflow, which shows the logo */}
                 <TopBar />
-                <div className="form row">
-                    <div className="logo-box col s3">
-                        <i className="library-music material-icons">library_music</i>
+                <div className={s.form + " row"}>
+                    <div className={s.logo_box + " col s3"}>
+                        <i className={s.library_music + " material-icons"}>library_music</i>
                         <div>
                             <b>Create your account <br />
                             in 2 simple steps</b>  <br />


### PR DESCRIPTION
**THE PROBLEM:**
Webpack will find all of our CSS style sheets and insert them at the top of our document which means it applies to all of our elements. Say you have a class of "form" in one component--if you use a similarly named "form" in another, it'll have the CSS of the former component.

**SOLUTION:**
We use CSS modules, which allows us to specify CSS local to a single component. You can configure webpack to come up with unique class names based on the component.